### PR TITLE
fix: replace logging.basicConfig with scoped logger configuration

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -1230,6 +1230,22 @@ def main() -> None:
 
 TLogLevel: TypeAlias = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
+
+def _configure_logging(level: str | int) -> None:
+    """Configure the ``conda_lock`` logger without touching the root logger.
+
+    Using ``logging.basicConfig`` configures the root logger, which conflicts
+    with the conda plugin system (see conda/conda#15872).  Instead we attach a
+    ``StreamHandler`` to the ``conda_lock`` package logger so that only
+    conda-lock messages are affected.
+    """
+    root = logging.getLogger("conda_lock")
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
+        root.addHandler(handler)
+    root.setLevel(level)
+
 CONTEXT_SETTINGS = {"show_default": True, "help_option_names": ["--help", "-h"]}
 
 
@@ -1430,7 +1446,7 @@ def lock(
         version: The version of conda-lock used to generate this lock file.
         timestamp: The approximate timestamp of the output file in ISO8601 basic format.
     """
-    logging.basicConfig(level=log_level)
+    _configure_logging(log_level)
 
     # Set the flag for deleting temporary paths (files/dirs)
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1605,7 +1621,7 @@ def click_install(
         sys.exit(1)
 
     """Perform a conda install"""
-    logging.basicConfig(level=log_level)
+    _configure_logging(log_level)
 
     # Set the flag for deleting temporary paths
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1729,7 +1745,7 @@ def render(
     platform: Sequence[str],
 ) -> None:
     """Render multi-platform lockfile into single-platform env or explicit file"""
-    logging.basicConfig(level=log_level)
+    _configure_logging(log_level)
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem
@@ -2035,7 +2051,7 @@ def render_lock_spec(  # noqa: C901
             )
         editables.append(EditableDependency(name=name, path=path))
 
-    logging.basicConfig(level=log_level)
+    _configure_logging(log_level)
 
     # Set Pypi <--> Conda lookup file location
     mapping_url = (

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -317,8 +317,9 @@ def virtual_package_repo_from_specification(
 
 
 if __name__ == "__main__":
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(logging.DEBUG)
+    from conda_lock.conda_lock import _configure_logging
+
+    _configure_logging(logging.DEBUG)
     fil = (
         pathlib.Path(__file__).parent.parent
         / "tests"

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -317,7 +317,8 @@ def virtual_package_repo_from_specification(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
     fil = (
         pathlib.Path(__file__).parent.parent
         / "tests"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace all `logging.basicConfig()` calls with a scoped logger configuration that only affects the `conda_lock` package logger, not the root logger. This is required for the conda plugin system to work properly.

## Motivation

As discussed in [conda/conda-lock#905](https://github.com/conda/conda-lock/pull/905) and [conda/conda#15872](https://github.com/conda/conda/issues/15872), calling `logging.basicConfig()` configures the **root logger**, which conflicts with conda's own logging setup when conda-lock is used as a conda plugin. This causes conda plugin subcommands to misbehave (e.g. suppressing log output).

The same fix was applied to conda-smithy in [conda-forge/conda-smithy#2512](https://github.com/conda-forge/conda-smithy/pull/2512).

## Changes

- **`conda_lock/conda_lock.py`**: Added a `_configure_logging()` helper that attaches a `StreamHandler` to the `conda_lock` package logger (instead of the root logger) and replaced all 4 `logging.basicConfig(level=log_level)` calls with `_configure_logging(log_level)`.
- **`conda_lock/virtual_package.py`**: Replaced the `logging.basicConfig()` call in the `__main__` guard with scoped logger configuration.
- Vendored code (`conda_lock/_vendor/`) is left untouched.

## Testing

- Ruff: all checks passed
- Mypy: no issues found
- CLI smoke test: `conda-lock --help` works correctly
- Unit test for `_configure_logging()`: verifies handler is added only once, level is set correctly, and root logger is not affected
- Existing test suite: 67 passed, 42 skipped (skips are due to conda not being installed in CI, Docker not available, and pre-existing timeouts — none related to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5306946-1b05-45f8-a825-d8600371d0c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5306946-1b05-45f8-a825-d8600371d0c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

